### PR TITLE
fix: Allow multiple dispatch instances to work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,6 +314,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "rand",
  "ratatui",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ zbus = { version = "5.11", default-features = false, features = ["tokio"] }
 http-body-util = { version = "0.1", default-features = false }
 serde_json = { version = "1.0", default-features = false }
 anyhow = { version = "1.0", default-features = false }
+rand = { version = "0.9", default-features = false, features = ["thread_rng"] }
 
 [build-dependencies]
 uefi-reset = { version = "1.0", artifact = "bin", target = "x86_64-unknown-uefi" }

--- a/src/avahi.rs
+++ b/src/avahi.rs
@@ -71,6 +71,9 @@ impl AvahiService {
     pub async fn register(&self, name: &str, port: u16, txt: &[(&str, &str)]) -> Result<()> {
         let service_type = format!("_{name}._tcp");
 
+        // Generate a random suffix to avoid service name collisions on the network.
+        let service_name = format!("{name}-{:04x}", rand::random::<u16>());
+
         // Convert TXT records to the format expected by Avahi
         let txt: Vec<Vec<u8>> = txt
             .iter()
@@ -84,7 +87,7 @@ impl AvahiService {
         // domain: "" (use default)
         // host: "" (use local hostname)
         self.entry_group
-            .add_service(-1, 0, 0, name, &service_type, "", "", port, txt)
+            .add_service(-1, 0, 0, &service_name, &service_type, "", "", port, txt)
             .await
             .context("Failed to add service")?;
 


### PR DESCRIPTION
This PR has been updated. Description of current version:

Add 16-bit random suffix to Avahi service name to avoid collisions.
Add rand crate as a dependency of dispatch in a way that doesn't add new deps.

Resolves: #4 
