### PR TITLE
fix: Allow asset download from private repos

### DIFF
--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -49,11 +49,35 @@ impl Server {
             attempt.stop()
         });
 
+        let mut client_builder = Client::builder().redirect(policy);
+        if github.is_private() {
+            // Build client with GitHub authentication if token is available
+            if let Some(token) = github.token() {
+                let mut headers = reqwest::header::HeaderMap::new();
+                let mut auth_value = format!("token {token}")
+                    .parse::<reqwest::header::HeaderValue>()
+                    .unwrap();
+                auth_value.set_sensitive(true);
+                headers.insert(reqwest::header::AUTHORIZATION, auth_value);
+                headers.insert(
+                    reqwest::header::USER_AGENT,
+                    concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"))
+                        .parse()
+                        .unwrap(),
+                );
+                headers.insert(
+                    reqwest::header::ACCEPT,
+                    "application/octet-stream".parse().unwrap(),
+                );
+                client_builder = client_builder.default_headers(headers);
+            }
+        }
+
         Ok(Self {
             listener,
             status,
             github,
-            client: Client::builder().redirect(policy).build()?,
+            client: client_builder.build()?,
             path,
         })
     }

--- a/src/http/service.rs
+++ b/src/http/service.rs
@@ -45,6 +45,31 @@ impl Service {
             path,
         }
     }
+
+    /// Build a reqwest request for an asset, handling private/public repos and method.
+    fn build_request(
+        gh: &GitHub,
+        asset: &Asset,
+        client: &Client,
+        method: &Method,
+    ) -> reqwest::RequestBuilder {
+        let url = if gh.is_private() {
+            format!(
+                "https://api.github.com/repos/{}/{}/releases/assets/{}",
+                gh.owner(),
+                gh.repo(),
+                asset.id
+            )
+        } else {
+            asset.url.clone()
+        };
+
+        match method {
+            &Method::HEAD => client.head(url),
+            // Only HEAD and GET are expected; all others default to GET.
+            _ => client.get(url),
+        }
+    }
 }
 
 impl hyper::service::Service<Request<Incoming>> for Service {
@@ -110,7 +135,12 @@ impl hyper::service::Service<Request<Incoming>> for Service {
                         None => return Ok(POWEROFF_EFI.reply(None, Type::Efi, EMPTY)),
 
                         // Send the request (possibly redirecting...)
-                        Some(asset) => (client.head(asset.url).send().await?, asset.mime),
+                        Some(asset) => {
+                            let request =
+                                Self::build_request(&github, &asset, &client, &Method::HEAD);
+
+                            (request.send().await?, asset.mime)
+                        }
                     }
                 }
 
@@ -122,7 +152,10 @@ impl hyper::service::Service<Request<Incoming>> for Service {
 
                         // Send the request (possibly redirecting...)
                         Some(asset) => {
-                            let response = client.get(asset.url).send().await?;
+                            let request =
+                                Self::build_request(&github, &asset, &client, &Method::GET);
+
+                            let response = request.send().await?;
                             status.lock().await.update().downloading(remote);
                             (response, asset.mime)
                         }


### PR DESCRIPTION
Allow asset download from private repos: use URL with asset ID, supply token, etc.
Use --public to download in a way (the old way) that only works for public repos.

Resolves: #18